### PR TITLE
Adapt to latest conduit changes

### DIFF
--- a/lib/cohttp_mirage.ml
+++ b/lib/cohttp_mirage.ml
@@ -73,7 +73,7 @@ module Server (Flow: V1_LWT.FLOW) = struct
   module XResponse = Cohttp_lwt.Make_response(HTTP_IO)
   include Cohttp_lwt.Make_server(HTTP_IO)(XRequest)(XResponse)
 
-  let listen spec flow ic oc =
+  let listen spec flow =
     let ch = Channel.create flow in
     callback spec flow ch ch
 

--- a/lib/cohttp_mirage.ml
+++ b/lib/cohttp_mirage.ml
@@ -19,9 +19,9 @@
 open Lwt
 open Sexplib.Conv
 
-module Client (Conduit:Conduit_mirage.S) = struct
+module Client = struct
 
-  module Channel = Channel.Make(Conduit.Flow)
+  module Channel = Channel.Make(Conduit_mirage.Flow)
   module HTTP_IO = Cohttp_mirage_io.Make(Channel)
 
   module Net_IO = struct
@@ -31,24 +31,22 @@ module Client (Conduit:Conduit_mirage.S) = struct
     type 'a io = 'a Lwt.t
     type ic = Channel.t
     type oc = Channel.t
-    type flow = Conduit.flow
+    type flow = Conduit_mirage.Flow.flow
 
     type ctx = {
       resolver: Resolver_lwt.t;
-      ctx: Conduit.ctx;
-    } with sexp_of
+      conduit : Conduit_mirage.t;
+    }
+
+    let sexp_of_ctx { resolver; _ } = Resolver_lwt.sexp_of_t resolver
 
     let default_ctx =
-      { resolver = Resolver_mirage.localhost;
-        ctx = Conduit.default_ctx }
+      { resolver = Resolver_mirage.localhost; conduit = Conduit_mirage.empty }
 
     let connect_uri ~ctx uri =
-      Resolver_lwt.resolve_uri ~uri ctx.resolver
-      >>= fun endp ->
-      Conduit.endp_to_client ~ctx:ctx.ctx endp
-      >>= fun client ->
-      Conduit.connect ~ctx:ctx.ctx client
-      >>= fun (flow,ic,oc) ->
+      Resolver_lwt.resolve_uri ~uri ctx.resolver >>= fun endp ->
+      Conduit_mirage.client endp >>= fun client ->
+      Conduit_mirage.connect ctx.conduit client >>= fun flow ->
       let ch = Channel.create flow in
       return (flow, ch, ch)
 
@@ -57,7 +55,8 @@ module Client (Conduit:Conduit_mirage.S) = struct
     let close ic oc = ignore_result (Channel.close ic)
 
   end
-  let ctx resolver ctx = { Net_IO.resolver; ctx }
+  let ctx resolver conduit = { Net_IO.resolver; conduit }
+
   (* Build all the core modules from the [Cohttp_lwt] functors *)
   module XRequest = Cohttp_lwt.Make_request(HTTP_IO)
   module XResponse = Cohttp_lwt.Make_response(HTTP_IO)

--- a/lib/cohttp_mirage.mli
+++ b/lib/cohttp_mirage.mli
@@ -18,9 +18,9 @@
 
 (** Cohttp implementation for mirage *)
 
-module Client (Conduit:Conduit_mirage.S): sig
+module Client: sig
   include Cohttp_lwt.Client
-  val ctx: Resolver_lwt.t -> Conduit.ctx -> ctx
+  val ctx: Resolver_lwt.t -> Conduit_mirage.t -> ctx
 end
 (** HTTP client. *)
 

--- a/lib/cohttp_mirage.mli
+++ b/lib/cohttp_mirage.mli
@@ -26,6 +26,6 @@ end
 
 module Server (Flow: V1_LWT.FLOW): sig
   include Cohttp_lwt.Server
-  val listen: t -> Flow.flow -> 'a -> 'b -> unit Lwt.t
+  val listen: t -> Flow.flow -> unit Lwt.t
 end
 (** HTTP server *)


### PR DESCRIPTION
Main changes:
- the http callback now just takes a flow (no input and output channels)
- no more functor for the Client, it's using the new dynamic flow module available in Conduit.
