### PR TITLE
Add a preapplied server with conduit

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,0 +1,3 @@
+B _build/**
+S lib/**
+PKG cohttp.lwt-core channel conduit.mirage sexplib

--- a/lib/cohttp_mirage.ml
+++ b/lib/cohttp_mirage.ml
@@ -73,3 +73,13 @@ module Server (Flow: V1_LWT.FLOW) = struct
     callback spec flow ch ch
 
 end
+
+module Server_with_conduit = struct
+
+  include Server(Conduit_mirage.Flow)
+
+  let connect t =
+    let listen s f = Conduit_mirage.listen t s (listen f) in
+    Lwt.return (`Ok listen)
+
+end

--- a/lib/cohttp_mirage.mli
+++ b/lib/cohttp_mirage.mli
@@ -29,3 +29,11 @@ module Server (Flow: V1_LWT.FLOW): sig
   val listen: t -> IO.conn -> unit Lwt.t
 end
 (** HTTP server *)
+
+module Server_with_conduit : sig
+  include Cohttp_lwt.Server with type IO.conn = Conduit_mirage.Flow.flow
+  val connect:
+    Conduit_mirage.t ->
+    [> `Ok of Conduit_mirage.server -> t -> unit Lwt.t ] Lwt.t
+end
+(** HTTP server with conduit. *)


### PR DESCRIPTION
The logic behind this pre-applied module is that
[it's actually hard-coded in the mirage DSL](https://github.com/mirage/mirage/blob/master/lib/mirage.ml#L1898-L1909).

The less logic in the mirage DSL, the better, so here it is. I'm not sure if
it's actually the way you want it, but a module with a connect is really preferable regardless.
