### PR TITLE
Close channel after callback executed (request stream ended or no keep alive)

### DIFF
--- a/lib/cohttp_mirage.ml
+++ b/lib/cohttp_mirage.ml
@@ -70,7 +70,8 @@ module Server (Flow: V1_LWT.FLOW) = struct
 
   let listen spec flow =
     let ch = Channel.create flow in
-    callback spec flow ch ch
+    callback spec flow ch ch >>= fun () ->
+    Channel.close ch
 
 end
 


### PR DESCRIPTION
Otherwise we end up in situations where the TCP session is closed on the client
side (or no keep-alive is used), but the server still keeps the TCP state around

This is reproducible both on Unix (using tap0) and Xen.  It didn't occur too
much more recently since code was copied around which does the `close`:
https://github.com/mirage/mirage-www/blob/0456a4af2c2902e71c441aab7aeb14b2f0309be5/src/dispatch_tls.ml#L45-L47

And, the TLS close closes the underlying flow (https://github.com/mirleft/ocaml-tls/blob/3428c0f37d4f7df94b371d34307112898c3ad6ea/mirage/tls_mirage.ml#L150-L157)

In general, this should be reworked: each layer should only close its own
protocol state when closing -- it would be good to be able to start a TCP
session, start TLS, data, end TLS, plain data, start another TLS, ...

@avsm @Engil @samoht this fixes https://github.com/Engil/Canopy/issues/14
