### PR TITLE
make sure to close the channel in all cases

### DIFF
--- a/lib/cohttp_mirage.ml
+++ b/lib/cohttp_mirage.ml
@@ -70,8 +70,8 @@ module Server (Flow: V1_LWT.FLOW) = struct
 
   let listen spec flow =
     let ch = Channel.create flow in
-    callback spec flow ch ch >>= fun () ->
-    Channel.close ch
+    Lwt.finalize (fun () -> callback spec flow ch ch)
+      (fun () -> Channel.close ch)
 
 end
 


### PR DESCRIPTION
(even if a write failed or connection was interrupted)

the underlying stacks will only then free up the resources
(direct: TCP control block (pcb.ml), socket: fd)

(I talked about this in the [mirage call yesterday](http://canopy.mirage.io/irclogs/04-05-2016) `04-05-2016 15:44 hannes it is leaking memory... guess what I've a new bug for this weekend ;)`)
