### PR TITLE
`close` should call `flush` then `disconnect`

### DIFF
--- a/src/cohttp_mirage.ml
+++ b/src/cohttp_mirage.ml
@@ -47,8 +47,10 @@ module Client = struct
 
     let close_in _ = ()
     let close_out _ = ()
-    let close ic _oc = Lwt.ignore_result (Channel.close ic)
-
+    let close ic _oc =
+      Lwt.ignore_result @@ Lwt.finalize
+        (fun () -> Channel.flush ic)
+        (fun () -> Channel.disconnect ic)
   end
   let ctx resolver conduit = { Net_IO.resolver; conduit }
 


### PR DESCRIPTION
Previously `Channel.close x` was implemented as

  Lwt.finalize (fun () -> Channel.flush x) (fun () -> Flow.close x.flow)

and previously `Flow.close` would free any resources (or at least allow
them to be GCed later).

[mirage/mirage#550] clarifies the `FLOW.close` should signal no more
data will be sent, while still allowing data to be received. This means
the connection is still open.

From cohttp's point of view, it wants `close` to flush any buffered data
and then to deallocate any connection state. Therefore this `close` should
be `Channel.flush` followed by `Flow.disconnect.`

Signed-off-by: David Scott dave@recoil.org
