### PR TITLE
Add Cohttp_mirage_static for plain HTTP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ env:
    - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git"
    - PRE_INSTALL_HOOK="cd /home/opam/opam-repository && git pull origin master && opam update -u -y"
  matrix:
-   - DISTRO=debian-stable OCAML_VERSION=4.02.3
+   - DISTRO=debian-stable OCAML_VERSION=4.03.0
    - DISTRO=ubuntu-16.04 OCAML_VERSION=4.03.0
    - DISTRO=alpine OCAML_VERSION=4.04.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 * Add `Cohttp_mirage_static` module for serving static files from a
   read-only key-value store.  Includes magic mime detection.
 * Improve the ocamldoc strings for the modules.
+* Constrain supported OCaml version to 4.03.0+ or higher, as with Mirage 3.0.
 
 ### 3.0.0 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+### 3.1.0
+
+* Add `Cohttp_mirage_static` module for serving static files from a
+  read-only key-value store.  Includes magic mime detection.
+
 ### 3.0.0 
 
 * Port to MirageOS 3 CHANNEL interface.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 * Add `Cohttp_mirage_static` module for serving static files from a
   read-only key-value store.  Includes magic mime detection.
+* Improve the ocamldoc strings for the modules.
 
 ### 3.0.0 
 

--- a/_tags
+++ b/_tags
@@ -5,4 +5,4 @@ true: warn_error(+1..49+60), warn(A-4-41-44)
 <test> : include
 
 <src/**>: package(lwt cohttp.lwt-core result)
-<src/**>: package(conduit.mirage mirage-flow-lwt mirage-channel-lwt)
+<src/**>: package(conduit.mirage mirage-flow-lwt mirage-channel-lwt astring magic-mime)

--- a/build
+++ b/build
@@ -1,0 +1,24 @@
+#!/bin/sh
+# This script is only used for developement. It is removed by the
+# distribution process.
+
+set -e
+
+OCAMLBUILD=${OCAMLBUILD:="ocamlbuild -use-ocamlfind -classic-display \
+                                     -tag debug"}
+
+action ()
+{
+    case $1 in
+        default)    topkg build ;;
+        test|tests) topkg build && topkg test ;;
+        doc)        shift; topkg doc --dev $* ;;
+        api-doc)    shift; topkg doc $* ;;
+        clean)      topkg clean ;;
+        *)          $OCAMLBUILD $* ;;
+    esac
+}
+
+if [ $# -eq 0 ];
+then action default ;
+else action $*; fi

--- a/doc/api.odocl
+++ b/doc/api.odocl
@@ -1,1 +1,3 @@
 Cohttp_mirage
+Cohttp_mirage_io
+Cohttp_mirage_static

--- a/opam
+++ b/opam
@@ -22,5 +22,5 @@ depends: [
   "astring"
   "magic-mime"
 ]
-available: [ocaml-version >= "4.00.0"]
+available: [ocaml-version >= "4.03.0"]
 tags: "org:mirage"

--- a/opam
+++ b/opam
@@ -19,6 +19,8 @@ depends: [
   "mirage-conduit" {>= "2.2.0"}
   "lwt" {>= "2.4.3"}
   "cohttp" {>= "0.18.0"}
+  "astring"
+  "magic-mime"
 ]
 available: [ocaml-version >= "4.00.0"]
 tags: "org:mirage"

--- a/pkg/META
+++ b/pkg/META
@@ -1,6 +1,6 @@
 description = "Cohttp implementation suitable to run in a MirageOS unikernel"
 version = "%%VERSION_NUM%%"
-requires = "cohttp.lwt-core mirage-channel-lwt conduit.mirage sexplib mirage-flow-lwt"
+requires = "cohttp.lwt-core mirage-channel-lwt conduit.mirage sexplib mirage-flow-lwt magic-mime astring"
 archive(byte) = "mirage-http.cma"
 archive(native) = "mirage-http.cmxa"
 plugin(byte) = "mirage-http.cma"

--- a/src/cohttp_mirage.mli
+++ b/src/cohttp_mirage.mli
@@ -17,7 +17,7 @@
  * %%NAME%% %%VERSION%%
  *)
 
-(** Cohttp implementation for mirage *)
+(** Cohttp client and server implementations for Mirage *)
 
 (** HTTP client. *)
 module Client: sig

--- a/src/cohttp_mirage_io.mli
+++ b/src/cohttp_mirage_io.mli
@@ -17,6 +17,8 @@
  * %%NAME%% %%VERSION%%
  *)
 
+(** Cohttp IO implementation using Mirage channels. *)
+
 module Make (Channel: Mirage_channel_lwt.S) : Cohttp.S.IO
   with type 'a t = 'a Lwt.t
    and type ic = Channel.t

--- a/src/cohttp_mirage_static.ml
+++ b/src/cohttp_mirage_static.ml
@@ -1,0 +1,81 @@
+(*
+ * Copyright (c) 2012-2017 Anil Madhavapeddy <anil@recoil.org>
+ * Copyright (c) 2013-2015 Thomas Gazagnaire <thomas@gazazagnaire.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ * %%NAME%% %%VERSION%%
+ *)
+
+module HTTP(FS: Mirage_kv_lwt.RO)(S: Cohttp_lwt.Server) = struct
+
+  open Lwt.Infix
+  open Astring
+
+  let failf fmt = Fmt.kstrf Lwt.fail_with fmt
+
+  let read_fs t name =
+  FS.size t name >>= function
+  | Error e -> failf "read: %a" FS.pp_error e
+  | Ok size ->
+      FS.read t name 0L size >>= function
+      | Error e -> failf "read %a" FS.pp_error e
+      | Ok bufs -> Lwt.return (Cstruct.copyv bufs)
+
+  let exists t name =
+  FS.mem t name >>= function
+  | Ok true -> Lwt.return_true
+  | _ -> Lwt.return_false
+
+  let dispatcher request_fn =
+    let rec fn fs uri =
+    match Uri.path uri with
+    | ("" | "/") as path ->
+      Logs.info (fun f -> f "request for '%s'" path);
+      fn fs (Uri.with_path uri "index.html")
+    | path when String.is_suffix ~affix:"/" path ->
+      Logs.info (fun f -> f "request for '%s'" path);
+      fn fs (Uri.with_path uri "index.html")
+    | path ->
+      Logs.info (fun f -> f "request for '%s'" path);
+      Lwt.catch (fun () ->
+        read_fs fs path >>= fun body ->
+        let mime_type = Magic_mime.lookup path in
+        let headers = Cohttp.Header.init_with "content-type" mime_type in
+        let headers = match request_fn with
+         | None -> headers
+         | Some fn -> fn uri headers in
+        S.respond_string ~status:`OK ~body ~headers ()
+      ) (fun _exn ->
+         let with_index = Fmt.strf "%s/index.html" path in
+         exists fs with_index >>= function
+         | true -> fn fs (Uri.with_path uri with_index)
+         | false ->  S.respond_not_found ()
+      )
+    in fn
+
+  let start ~http_port ?request_fn fs http =
+
+    let callback (_, cid) request _body =
+      let uri = Cohttp.Request.uri request in
+      let cid = Cohttp.Connection.to_string cid in
+      Logs.info (fun f -> f "[%s] serving %s" cid (Uri.to_string uri));
+      dispatcher request_fn fs uri
+    in
+    let conn_closed (_, cid) =
+      let cid = Cohttp.Connection.to_string cid in
+      Logs.info (fun f -> f "[%s] closing" cid);
+    in
+    Logs.info (fun f -> f "listening on %d/TCP" http_port);
+    http (`TCP http_port) (S.make ~conn_closed ~callback ())
+end

--- a/src/cohttp_mirage_static.mli
+++ b/src/cohttp_mirage_static.mli
@@ -1,0 +1,36 @@
+(*
+ * Copyright (c) 2012-2017 Anil Madhavapeddy <anil@recoil.org>
+ * Copyright (c) 2013-2015 Thomas Gazagnaire <thomas@gazazagnaire.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ * %%NAME%% %%VERSION%%
+ *)
+
+(** Serve static HTTP sites from a Mirage KV store *)
+
+(** Plain HTTP file serving from a read-only key-value store. *)
+module HTTP(FS: Mirage_kv_lwt.RO)(S:Cohttp_lwt.Server) : sig
+
+  (** [start http_port ?request_fn fs http] will start a static
+    HTTP server listening on [http_port].  The files to serve will
+    be looked up from the [fs] key-value store.
+
+    If [request_fn] is supplied, the URI and default header set
+    (including the MIME content-type header) will be passed to it
+    and the response used as the response header set instead. *)
+  
+  val start: http_port:int ->
+    ?request_fn:(Uri.t -> Cohttp.Header.t -> Cohttp.Header.t) ->
+    FS.t -> ([> `TCP of int ] -> S.t -> 'a) -> 'a
+end

--- a/src/cohttp_mirage_static.mli
+++ b/src/cohttp_mirage_static.mli
@@ -17,7 +17,7 @@
  * %%NAME%% %%VERSION%%
  *)
 
-(** Serve static HTTP sites from a Mirage KV store *)
+(** Serve static HTTP sites from a Mirage key-value store. *)
 
 (** Plain HTTP file serving from a read-only key-value store. *)
 module HTTP(FS: Mirage_kv_lwt.RO)(S:Cohttp_lwt.Server) : sig

--- a/src/mirage-http.mllib
+++ b/src/mirage-http.mllib
@@ -1,2 +1,3 @@
 Cohttp_mirage
 Cohttp_mirage_io
+Cohttp_mirage_static


### PR DESCRIPTION
This lets the boilerplate for static HTTP serving simply be:

```
module HTTP (FS: Mirage_types_lwt.KV_RO) (S: Cohttp_lwt.Server) = struct
  module Static = Cohttp_mirage_static.HTTP(FS)(S)
  let start fs http =
    let http_port = Key_gen.http_port () in
    Static.start ~http_port fs http
end
```

Will also add a HTTPS module in a later PR, but not included yet.